### PR TITLE
Fix for one-shot

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -177,17 +177,23 @@ class VymangaScraper:
         Returns:
             List of Chapter objects
         """
-        chapters = []
-
+        
         # Find chapter list container
         chapter_list_div = soup.find('div', class_='list')
         if not chapter_list_div:
             logger.warning("No chapter list found")
-            return chapters
 
         # Find all chapter links
-        chapter_links = chapter_list_div.find_all('a', class_='list-group-item')
-
+        if chapter_list_div:
+            chapter_links = chapter_list_div.find_all('a', class_='list-group-item')
+        else:
+            chapter_links = soup.select('a[id^=chapter-]')
+        
+        if not chapter_links:
+            logger.warning("No chapters found")
+            return []
+        
+        chapters = []
         for link in reversed(chapter_links): # from old to new
             try:
                 # Extract chapter number from id

--- a/scraper.py
+++ b/scraper.py
@@ -190,16 +190,16 @@ class VymangaScraper:
 
         for link in chapter_links:
             try:
-                # Extract chapter number and title from text
-                chapter_text = link.get_text(strip=True)
-                chapter_match = re.search(r'Chapter\s+(\d+(?:\.\d+)?)', chapter_text, re.IGNORECASE)
-
-                if not chapter_match:
-                    continue
-
-                chapter_number = float(chapter_match.group(1))
+                # Extract chapter number from id
+                chapter_match = re.findall(r'chapter-(\d+(?:\.\d+)?)', link.get('id'))
+                if chapter_match:
+                    chapter_number = float(chapter_match[0])
+                else:
+                    # Fallback to last number
+                    chapter_number = 0.0 if not chapters else chapters[-1].number + 0.001
 
                 # Extract chapter title - everything after "Chapter X.X : "
+                chapter_text = link.get_text(strip=True)
                 title_match = re.search(r'Chapter\s+\d+(?:\.\d+)?\s*:\s*(.+)', chapter_text, re.IGNORECASE)
                 if title_match:
                     full_title = title_match.group(1).strip()


### PR DESCRIPTION
One-shots ([e.g.](https://vymanga.com/manga/touhou--remilias-new-years-eve-doujinshi)) don't have chapter list container.
This PR finds chapters of one-shot by their id.